### PR TITLE
Added 'compared to last period.' after the amount/percentage

### DIFF
--- a/app/components/matey/active_users_component.html.erb
+++ b/app/components/matey/active_users_component.html.erb
@@ -6,7 +6,7 @@
       </div>
       <div class="col-auto">
         <p class="card-text text-end mb-0">
-          <%= (@change_active_number > 0 ? "+" : "") + @change_active_number.to_s + " / " + @change_active_percent.to_s + "%" %>
+          <%= (@change_active_number > 0 ? "+" : "") + @change_active_number.to_s + " / " + @change_active_percent.to_s + "%" + " compared to last period." %>
         </p>
       </div><!-- .col -->
     </div><!-- .row -->

--- a/app/components/matey/active_users_component.html.erb
+++ b/app/components/matey/active_users_component.html.erb
@@ -6,7 +6,7 @@
       </div>
       <div class="col-auto">
         <p class="card-text text-end mb-0">
-          <%= (@change_active_number > 0 ? "+" : "") + @change_active_number.to_s + " / " + @change_active_percent.to_s + "%" + " compared to last period." %>
+          <%= (@change_active_number > 0 ? "+" : "") + @change_active_number.to_s + " / " + @change_active_percent.to_s + "%" %> compared to last period.
         </p>
       </div><!-- .col -->
     </div><!-- .row -->

--- a/app/components/matey/new_activity_component.html.erb
+++ b/app/components/matey/new_activity_component.html.erb
@@ -6,7 +6,7 @@
       </div>
       <div class="col-auto">
         <p class="card-text text-end mb-0">
-          <%= (@change_active_number > 0 ? "+" : "") + @change_active_number.to_s + " / " + @change_active_percent.to_s + "%" %>
+          <%= (@change_active_number > 0 ? "+" : "") + @change_active_number.to_s + " / " + @change_active_percent.to_s + "%" + " compared to last period." %>
         </p>
       </div><!-- .col -->
     </div><!-- .row -->

--- a/app/components/matey/new_activity_component.html.erb
+++ b/app/components/matey/new_activity_component.html.erb
@@ -6,7 +6,7 @@
       </div>
       <div class="col-auto">
         <p class="card-text text-end mb-0">
-          <%= (@change_active_number > 0 ? "+" : "") + @change_active_number.to_s + " / " + @change_active_percent.to_s + "%" + " compared to last period." %>
+          <%= (@change_active_number > 0 ? "+" : "") + @change_active_number.to_s + " / " + @change_active_percent.to_s + "%" %> compared to last period.
         </p>
       </div><!-- .col -->
     </div><!-- .row -->

--- a/app/components/matey/new_users_component.html.erb
+++ b/app/components/matey/new_users_component.html.erb
@@ -6,7 +6,7 @@
       </div>
       <div class="col-auto">
         <p class="card-text text-end mb-0">
-          <%= (@change_new_number > 0 ? "+" : "") + @change_new_number.to_s + " / " + @change_new_percent.to_s + "%" + " compared to last period." %>
+          <%= (@change_new_number > 0 ? "+" : "") + @change_new_number.to_s + " / " + @change_new_percent.to_s + "%" %> compared to last period.
         </p>
       </div><!-- .col -->
     </div><!-- .row -->

--- a/app/components/matey/new_users_component.html.erb
+++ b/app/components/matey/new_users_component.html.erb
@@ -6,7 +6,7 @@
       </div>
       <div class="col-auto">
         <p class="card-text text-end mb-0">
-          <%= (@change_new_number > 0 ? "+" : "") + @change_new_number.to_s + " / " + @change_new_percent.to_s + "%" %>
+          <%= (@change_new_number > 0 ? "+" : "") + @change_new_number.to_s + " / " + @change_new_percent.to_s + "%" + " compared to last period." %>
         </p>
       </div><!-- .col -->
     </div><!-- .row -->


### PR DESCRIPTION
Added the text "_compared to last period._" after the amount/percentage for the following card components: 
- **active_users**
- **new_activity**
- **new_users**

<img width="457" alt="Screen Shot 2022-07-29 at 3 10 50 PM" src="https://user-images.githubusercontent.com/57971751/181828452-5265ce39-fd10-4b3f-82c6-12ca078167b9.png">

<img width="337" alt="Screen Shot 2022-07-29 at 3 09 42 PM" src="https://user-images.githubusercontent.com/57971751/181828311-dc313e46-60f5-48ce-ac5b-6c03a8b7a99c.png">
