### PR TITLE
Move ApplicationComponent to Matey namespace to avoid naming conflicts

### DIFF
--- a/app/components/matey/active_users_component.rb
+++ b/app/components/matey/active_users_component.rb
@@ -1,6 +1,6 @@
 require "ahoy_matey"
 
-class Matey::ActiveUsersComponent < ApplicationComponent
+class Matey::ActiveUsersComponent < Matey::ApplicationComponent
   def initialize(events:, time_window: 1.week)
     raise ArgumentError unless events.is_a?(ActiveRecord::Relation)
     raise ArgumentError unless time_window.is_a?(Integer)

--- a/app/components/matey/application_component.rb
+++ b/app/components/matey/application_component.rb
@@ -1,7 +1,7 @@
 require "view_component"
 require "ahoy_matey"
 
-class ApplicationComponent < ViewComponent::Base
+class Matey::ApplicationComponent < ViewComponent::Base
   include ActiveModel::Validations
 
   def before_render

--- a/app/components/matey/bounce_rate_component.rb
+++ b/app/components/matey/bounce_rate_component.rb
@@ -1,6 +1,6 @@
 require "ahoy_matey"
 
-class Matey::BounceRateComponent < ApplicationComponent
+class Matey::BounceRateComponent < Matey::ApplicationComponent
   def initialize(events:, visits:, limit: 5)
     # Determine the total number of user sessions to the website
     @total_number_of_user_visits = events.pluck(:visit_id).uniq.count

--- a/app/components/matey/browser_os_breakdown_component.rb
+++ b/app/components/matey/browser_os_breakdown_component.rb
@@ -1,4 +1,4 @@
-class Matey::BrowserOsBreakdownComponent < ApplicationComponent
+class Matey::BrowserOsBreakdownComponent < Matey::ApplicationComponent
   def initialize(visits:, time_window:)
     visits_in_time_window = visits.where(started_at: time_window.ago..)
     @visits_in_time_window = visits_in_time_window.count

--- a/app/components/matey/daily_active_users_component.rb
+++ b/app/components/matey/daily_active_users_component.rb
@@ -1,4 +1,4 @@
-class Matey::DailyActiveUsersComponent < ApplicationComponent
+class Matey::DailyActiveUsersComponent < Matey::ApplicationComponent
   def initialize(visits:, time_window:)
     @visits = visits
     @time_window = time_window

--- a/app/components/matey/new_activity_component.rb
+++ b/app/components/matey/new_activity_component.rb
@@ -1,4 +1,4 @@
-class Matey::NewActivityComponent < ApplicationComponent
+class Matey::NewActivityComponent < Matey::ApplicationComponent
   def initialize(events:, time_window: 1.week)
     raise ArgumentError unless events.is_a?(ActiveRecord::Relation)
     raise ArgumentError unless time_window.is_a?(Integer)

--- a/app/components/matey/new_users_component.rb
+++ b/app/components/matey/new_users_component.rb
@@ -1,4 +1,4 @@
-class Matey::NewUsersComponent < ApplicationComponent
+class Matey::NewUsersComponent < Matey::ApplicationComponent
   def initialize(users:, time_window: 1.week)
     @current_period = users.where(created_at: time_window.ago..Time.current).count
     previous_period = users.where(created_at: (2 * time_window).ago..time_window.ago).count

--- a/app/components/matey/top_events_component.rb
+++ b/app/components/matey/top_events_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Matey::TopEventsComponent < ApplicationComponent
+class Matey::TopEventsComponent < Matey::ApplicationComponent
   def initialize(events:, time_window: 1.week, limit: 5)
     raise ArgumentError unless events.is_a?(ActiveRecord::Relation)
     raise ArgumentError unless time_window.is_a?(Integer)

--- a/app/components/matey/top_visited_pages_table_component.rb
+++ b/app/components/matey/top_visited_pages_table_component.rb
@@ -1,4 +1,4 @@
-class Matey::TopVisitedPagesTableComponent < ApplicationComponent
+class Matey::TopVisitedPagesTableComponent < Matey::ApplicationComponent
   def initialize(events:, time_window: 1.week, limit: 10)
     # Group events by controller (:name) and action. Aggregate number of unique user actions
     @user_count_by_event = events.where(started_at: time_window.ago..).pluck(:landing_page).tally

--- a/app/components/matey/user_engagement_component.rb
+++ b/app/components/matey/user_engagement_component.rb
@@ -1,6 +1,6 @@
 require "ahoy_matey"
 
-class Matey::UserEngagementComponent < ApplicationComponent
+class Matey::UserEngagementComponent < Matey::ApplicationComponent
   def initialize(events:, user_id:, time_window: 1.week, limit: 10)
     @events_for_user = events.where_props(user_id: user_id).where(time: time_window.ago..Time.current).group(:name).count
     @count_by_event = @events_for_user.sort_by { |event, count| count }.last(limit).reverse

--- a/app/components/matey/visits_by_day_of_week_component.rb
+++ b/app/components/matey/visits_by_day_of_week_component.rb
@@ -1,6 +1,6 @@
 require "ahoy_matey"
 
-class Matey::VisitsByDayOfWeekComponent < ApplicationComponent
+class Matey::VisitsByDayOfWeekComponent < Matey::ApplicationComponent
   def initialize(visits:, time_window: 1.month, limit: 10, exclude_days: [])
     @time_window = time_window
 

--- a/lib/matey.rb
+++ b/lib/matey.rb
@@ -2,7 +2,7 @@
 
 require_relative "matey/version"
 
-require_relative "../app/components/application_component"
+require_relative "../app/components/matey/application_component"
 require_relative "../app/components/matey/active_users_component"
 require_relative "../app/components/matey/bounce_rate_component"
 require_relative "../app/components/matey/new_activity_component"


### PR DESCRIPTION
Fixes #73 by moving ApplicationComponent into the Matey namespace