### PR TITLE
potential fix: bin/console error

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require File.expand_path("../../spec/sample/config/environment.rb", __FILE__)
 require "bundler/setup"
 require "matey"
 

--- a/spec/sample/Gemfile
+++ b/spec/sample/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.1.2"
+ruby "3.1.3"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.2", ">= 7.0.2.3"


### PR DESCRIPTION
This is a potential fix for the `bin/console` error (issue #62)

The error mentions an uninitialized `Rails` constant. 

Steps I took to resolve this issue:
- the `Rails` constant is initialized
- the Ruby versions in the Gemfile and Container are aligned (3.1.3)