### PR TITLE
chore: bump view_component version to 3.9.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     matey (0.1.6)
       ahoy_matey (>= 4.0)
       groupdate (~> 6.4.0)
-      view_component (~> 2.74)
+      view_component (~> 3.9.0)
 
 GEM
   remote: https://rubygems.org/
@@ -246,7 +246,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
-    view_component (2.82.0)
+    view_component (3.9.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    matey (0.1.6)
+    matey (0.2.0)
       ahoy_matey (>= 4.0)
       groupdate (~> 6.4.0)
       view_component (~> 3.9.0)

--- a/lib/matey/version.rb
+++ b/lib/matey/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Matey
-  VERSION = "0.1.6"
+  VERSION = "0.2.0"
 end

--- a/matey.gemspec
+++ b/matey.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "view_component", "~> 2.74"
+  spec.add_dependency "view_component", "~> 3.9.0"
   spec.add_dependency "ahoy_matey", ">= 4.0"
   spec.add_dependency "groupdate", "~> 6.4.0"
 

--- a/spec/sample/Gemfile.lock
+++ b/spec/sample/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     matey (0.1.6)
       ahoy_matey (>= 4.0)
       groupdate (~> 6.4.0)
-      view_component (~> 2.74)
+      view_component (~> 3.9.0)
 
 GEM
   remote: https://rubygems.org/
@@ -290,7 +290,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
-    view_component (2.82.0)
+    view_component (3.9.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)

--- a/spec/sample/Gemfile.lock
+++ b/spec/sample/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /workspaces/matey
   specs:
-    matey (0.1.6)
+    matey (0.2.0)
       ahoy_matey (>= 4.0)
       groupdate (~> 6.4.0)
       view_component (~> 3.9.0)


### PR DESCRIPTION
Closes #89 

Opinionated update to `3.9.0` given the [recent CVE](https://github.com/ViewComponent/view_component/security/advisories/GHSA-wf2x-8w6j-qw37) in the [view_component](https://github.com/ViewComponent/view_component) package